### PR TITLE
Soporte de Unit Modbus por datalogger

### DIFF
--- a/Balanza/TareaDatalogger.cs
+++ b/Balanza/TareaDatalogger.cs
@@ -11,6 +11,7 @@ namespace Balanza
         public short inicio { get; set; }
         public short bitsdatalogger { get; set; }
         public int intervalo_lectura { get; set; }
+        public byte Unit { get; set; } = 1;
 
         // NUEVAS PROPIEDADES para la lógica centralizada de cambios
         public object ValorCrudoActual { get; set; }


### PR DESCRIPTION
## Summary
- agrega la propiedad Unit a TareaDatalogger con valor por defecto 1
- lee el campo unit desde la base y lo asigna a cada tarea de datalogger
- usa el Unit configurado en las lecturas Modbus y registra un log de depuración

## Testing
- dotnet build *(falla: comando no disponible en el entorno)*

------
https://chatgpt.com/codex/tasks/task_b_68d18bda312c832896da852f5ce04b1e