### PR TITLE
Update TipoLecturaFilter configuration value

### DIFF
--- a/Balanza/appsettings.sample.json
+++ b/Balanza/appsettings.sample.json
@@ -7,7 +7,7 @@
     "IntervaloImpactoBD": 5000,
     "MaxLogSizeMB": 10,
     "NivelLog": "debug",
-    "TipoLecturaFilter": 1,
+    "TipoLecturaFilter": 9,
     "TimeoutMs": 2000
   },
   "zeroTol": 0.05,


### PR DESCRIPTION
## Summary
- set the TipoLecturaFilter default to 9 in the sample settings file

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d1b2c7e3cc83289639d35643dd3eb1